### PR TITLE
Adding King's Digital Lab and its roles to the list of Institutions

### DIFF
--- a/head-of-rse/kings_digital_lab/roles.md
+++ b/head-of-rse/kings_digital_lab/roles.md
@@ -1,0 +1,21 @@
+# Roles at King's Digital Lab, King's College London
+
+* Director
+* Deputy Director
+* Research Software Analyst
+* Senior Research Software Analyst
+* Research Software UI/UX Designer
+* Senior Research Software UI/UX Designer
+* Senior Research Software Engineer
+* Principal Research Software Engineer
+* Research Software Project Manager
+* Systems Administrator
+* Senior Research Software Systems Manager
+
+## More information
+
+### Research Software (RS) Careers: Generic Learnings from King's Digital Lab, King's College London
+
+The Research Software (RS) role definitions in this document are based on those used in King’s Digital Lab (KDL). It has been distributed to offer ideas for other eResearch teams across King’s College London, the United Kingdom, and internationally. New versions will be added periodically.
+
+Public document deposited on [Zenodo](https://zenodo.org/record/2564790).

--- a/rse/kings_digital_lab/roles.md
+++ b/rse/kings_digital_lab/roles.md
@@ -1,0 +1,21 @@
+# Roles at King's Digital Lab, King's College London
+
+* Director
+* Deputy Director
+* Research Software Analyst
+* Senior Research Software Analyst
+* Research Software UI/UX Designer
+* Senior Research Software UI/UX Designer
+* Senior Research Software Engineer
+* Principal Research Software Engineer
+* Research Software Project Manager
+* Systems Administrator
+* Senior Research Software Systems Manager
+
+## More information
+
+### Research Software (RS) Careers: Generic Learnings from King's Digital Lab, King's College London
+
+The Research Software (RS) role definitions in this document are based on those used in King’s Digital Lab (KDL). It has been distributed to offer ideas for other eResearch teams across King’s College London, the United Kingdom, and internationally. New versions will be added periodically.
+
+Public document deposited on [Zenodo](https://zenodo.org/record/2564790).

--- a/senior-rse/kings_digital_lab/roles.md
+++ b/senior-rse/kings_digital_lab/roles.md
@@ -1,0 +1,21 @@
+# Roles at King's Digital Lab, King's College London
+
+* Director
+* Deputy Director
+* Research Software Analyst
+* Senior Research Software Analyst
+* Research Software UI/UX Designer
+* Senior Research Software UI/UX Designer
+* Senior Research Software Engineer
+* Principal Research Software Engineer
+* Research Software Project Manager
+* Systems Administrator
+* Senior Research Software Systems Manager
+
+## More information
+
+### Research Software (RS) Careers: Generic Learnings from King's Digital Lab, King's College London
+
+The Research Software (RS) role definitions in this document are based on those used in King’s Digital Lab (KDL). It has been distributed to offer ideas for other eResearch teams across King’s College London, the United Kingdom, and internationally. New versions will be added periodically.
+
+Public document deposited on [Zenodo](https://zenodo.org/record/2564790).


### PR DESCRIPTION
Adding the list of roles and a link to a public document in Zenodo with more details about the set up of King's Digital Lab, an RSE unit at King's College London, Faculty of Arts&Humanities.